### PR TITLE
Added method to get correct url

### DIFF
--- a/src/components/ShareComponents/index.tsx
+++ b/src/components/ShareComponents/index.tsx
@@ -3,12 +3,14 @@ import IconCopy from '@vtex/styleguide/lib/icon/Copy'
 import IconClose from '@vtex/styleguide/lib/icon/Close'
 import { FacebookIcon, TwitterIcon, WhatsappIcon } from '../icons'
 import copyTextToClipboard from '../../utils/copy'
-
+import { useLivestreamingContext } from '../../context'
+import { getUrlToShareLivestreaming } from '../../utils'
 import styles from './style.css'
 
 const ShareComponents = ({ handleClose }: { handleClose: () => void }) => {
-  const { origin, pathname } = window.location
-  const url = origin + pathname
+  const { account, idLivestreaming } = useLivestreamingContext()
+  const url = getUrlToShareLivestreaming(account, idLivestreaming)
+
   const urlshareSocial = {
     facebook: `https://www.facebook.com/sharer/sharer.php?u=${url}`,
     twitter: `https://twitter.com/intent/tweet?url=${url}`,

--- a/src/utils/getUrlToShareLivetreaming.ts
+++ b/src/utils/getUrlToShareLivetreaming.ts
@@ -1,0 +1,15 @@
+export const getUrlToShareLivestreaming = (
+  account: string,
+  idLivestreaming: string
+) => {
+  const { href } = window.location
+
+  const livePath = `${account}/${idLivestreaming}`
+
+  const isLivePathAtEnd =
+    href.indexOf(livePath) == href.length - livePath.length
+
+  const url = isLivePathAtEnd ? href : href + livePath
+
+  return url
+}

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -4,7 +4,8 @@ import { currencyFormat } from './getFormatMoney'
 import { getMobileOS, getDeviceType } from './getMobileOs'
 import { getRandomColor } from './getRandomColor'
 import Queue from './Queue'
-import {getRandomNumber } from './getRamdonNumber'
+import { getRandomNumber } from './getRamdonNumber'
+import { getUrlToShareLivestreaming } from './getUrlToShareLivetreaming'
 
 export {
   addToCart,
@@ -14,5 +15,6 @@ export {
   getMobileOS,
   getRandomColor,
   Queue,
-  getRandomNumber
+  getRandomNumber,
+  getUrlToShareLivestreaming
 }


### PR DESCRIPTION
What problem is this solving?
wrong url when sharing default live

Screenshot:
![image](https://user-images.githubusercontent.com/14004495/147293737-c89ec4b6-2a58-4473-9b1b-ac9433ffe8fa.png)
