### PR TITLE
send account when consulting platform products

### DIFF
--- a/src/services/getProducts.ts
+++ b/src/services/getProducts.ts
@@ -1,5 +1,6 @@
 import { apiCall } from './apiCall'
 import { config } from './../config'
+import { base64Encode } from './../utils'
 
 type GetProductsProps = {
   collectionId?: string | undefined
@@ -18,13 +19,13 @@ export const getProducts = async ({
   let products: Promise<any>
 
   if (originOfProducts === 'platform') {
-    products = getProductsPlatform()
+    products = getProductsPlatform(account)
   } else if (originOfProducts === 'CACE') {
     // Eliminar terminado el evento CACE
     products = getProductsCace({ collectionId })
   } else if (originOfProducts === 'globalPage') {
     if (account === 'plataforma') {
-      products = getProductsPlatform()
+      products = getProductsPlatform(account)
     } else {
       products = getProductsGlobalPage({ collectionId, account })
     }
@@ -115,8 +116,8 @@ const getProductsVtex = async ({ collectionId }: GetProductsProps) => {
   return null
 }
 
-const getProductsPlatform = async () => {
-  const url = config.API_PLATFORM + '/products'
+const getProductsPlatform = async (account: string | undefined) => {
+  const url = config.API_PLATFORM + `/products?account=${base64Encode(account)}`
 
   const { data } = await apiCall({ url })
 

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -1,0 +1,25 @@
+export const base64Encode = (
+    toConvert: string | Record<string, any> | null | undefined,
+  ) => {
+    let value;
+  
+    if (!toConvert) return null;
+  
+    // eslint-disable-next-line default-case
+    switch (typeof toConvert) {
+      case 'string':
+        value = toConvert;
+        break;
+  
+      case 'object':
+        value = JSON.stringify(toConvert);
+        break;
+    }
+  
+    return Buffer.from(value as string, 'utf-8').toString('base64');
+  };
+  
+  export const base64Decode = (toConvert: string | undefined) => {
+    if (!toConvert) return null;
+    return Buffer.from(toConvert, 'base64').toString('utf-8');
+  };

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -5,7 +5,7 @@ import { getMobileOS, getDeviceType } from './getMobileOs'
 import { getRandomColor } from './getRandomColor'
 import Queue from './Queue'
 import { getRandomNumber } from './getRamdonNumber'
-
+import { base64Encode, base64Decode } from './base64'
 export {
   addToCart,
   calcHeightApp,
@@ -14,5 +14,7 @@ export {
   getMobileOS,
   getRandomColor,
   Queue,
-  getRandomNumber
+  getRandomNumber,
+  base64Encode,
+  base64Decode
 }


### PR DESCRIPTION
send account when consulting platform products

the change is due to the fact that the platform will now be available for multiple accounts

In the image below, the products are loaded from a test account called "edwinmiranda":
![image](https://user-images.githubusercontent.com/84253846/150584496-4439b4cc-fbe0-4ed3-8a93-f3872197d365.png)
