### PR TITLE
add viewers to sendPropertiesToCms

### DIFF
--- a/src/components/LiveShopping.tsx
+++ b/src/components/LiveShopping.tsx
@@ -125,10 +125,14 @@ export const LiveShopping = (props: LiveShoppingProps) => {
       quickView,
       productsCarousel,
       sidebarProducts,
-      time
+      time,
+      viewers
     } = scriptProperties
 
-    if (setShowCounter) setShowCounter(showViewers)
+    const viewersFlag = viewers ? viewers : showViewers
+
+    if (setShowCounter) setShowCounter(viewersFlag)
+
     setSetting({
       account,
       idLivestreaming,
@@ -142,7 +146,7 @@ export const LiveShopping = (props: LiveShoppingProps) => {
       showQuickView: quickView,
       showProductsCarousel: productsCarousel,
       showSidebarProducts: sidebarProducts,
-      showViewers,
+      showViewers: viewersFlag,
       time
     })
   }, [scriptProperties])

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -97,7 +97,8 @@ const useWebSocket = ({ wssStream }: Props): InfoSocket => {
         isInGlobalPage,
         type,
         quickView,
-        showCarouselChatButton
+        showCarouselChatButton,
+        viewers
       } = JSON.parse(event.data)
 
       switch (action) {
@@ -166,7 +167,8 @@ const useWebSocket = ({ wssStream }: Props): InfoSocket => {
             quickView,
             pdp,
             kuikpay,
-            isInGlobalPage
+            isInGlobalPage,
+            viewers
           })
           break
 

--- a/src/typings/livestreaming.d.ts
+++ b/src/typings/livestreaming.d.ts
@@ -60,6 +60,7 @@ export declare interface ScriptProperties {
   pdp: boolean
   kuikpay: boolean
   isInGlobalPage: boolean
+  viewers?: boolean
 }
 export declare interface InfoSocket {
   socket: WebSocket | undefined


### PR DESCRIPTION
Add viewers to sendPropertiesToCms to avoid sending this property for a different action on the socket