### PR TITLE
add flag for viewers

### DIFF
--- a/src/components/LiveShopping.tsx
+++ b/src/components/LiveShopping.tsx
@@ -101,7 +101,8 @@ export const LiveShopping = (props: LiveShoppingProps) => {
     pinnedMessage: socketPinnedMessage,
     transmitiontype: socketTransmitiontype,
     showCarouselChatButton: socketCarouselChatButton,
-    activePromoMessage
+    activePromoMessage,
+    showCounter
   } = infoSocket || {}
 
   const getHeight = () => {
@@ -134,7 +135,9 @@ export const LiveShopping = (props: LiveShoppingProps) => {
       viewers
     } = scriptProperties
 
-    if (setShowCounter) setShowCounter(viewers)
+    const viewersFlag = viewers === undefined ? showCounter : viewers
+
+    if (setShowCounter) setShowCounter(viewersFlag)
 
     setSetting({
       account,
@@ -149,7 +152,7 @@ export const LiveShopping = (props: LiveShoppingProps) => {
       showQuickView: quickView,
       showProductsCarousel: productsCarousel,
       showSidebarProducts: sidebarProducts,
-      showViewers: viewers,
+      showViewers: viewersFlag,
       time
     })
   }, [scriptProperties])

--- a/src/typings/livestreaming.d.ts
+++ b/src/typings/livestreaming.d.ts
@@ -14,7 +14,7 @@ type LivestreamingProps = {
   showSidebarProducts: boolean
   showQuickView: boolean
   showProductsCarousel: boolean
-  showViewers: boolean
+  showViewers: boolean | undefined
   kuikpay: boolean
 }
 


### PR DESCRIPTION

This is because for the visualization of the viewers there are 2 cases

Case 1: when they are modified from the configuration block that is for IO and portal accounts
![image](https://user-images.githubusercontent.com/84253846/154386346-2239183d-af5b-40e4-8f8e-40d3ce74a662.png)

Case 2: When they are modified from the platform
![image](https://user-images.githubusercontent.com/84253846/154386418-e7fd01cb-7ef7-473d-b629-79a42ee4c74d.png)



