### PR TITLE
hide loader at the end of the send message event from the login and f…

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -116,6 +116,7 @@ export const Chat = ({
       setTimeout(() => setShowLoginWindow(true), 200)
       setSelectedGif(gif)
       setShowGif(false)
+      setShowLoader(false)
       return
     }
 
@@ -133,6 +134,8 @@ export const Chat = ({
     } else {
       setShowGif(false)
     }
+
+    setTimeout(() => setShowLoader(false), 1000)
   }
 
   const deleteMessage = useCallback(() => {

--- a/src/components/Chat/login/Login.tsx
+++ b/src/components/Chat/login/Login.tsx
@@ -111,6 +111,8 @@ export const Login = ({
   }
 
   const handlerSendDataToChat = async (event: React.SyntheticEvent) => {
+    if(!setShowLoader) return
+    setShowLoader(true)
     setDisabledBtn(true)
     event.preventDefault()
     event.persist()
@@ -118,7 +120,7 @@ export const Login = ({
 
     if (!isValid || !sendAccountId || !emailIsValid()) {
       setDisabledBtn(false)
-
+      setShowLoader(false)
       return
     }
 
@@ -137,6 +139,7 @@ export const Login = ({
     setShowLoginWindow(false)
     setUserIsLoggedInChat(true)
     setSendFirstMessage(true)
+    setShowLoader(false)
   }
 
   return (

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -29,7 +29,7 @@ const useWebSocket = ({ wssStream }: Props): InfoSocket => {
   )
   const [showCounter, setShowCounter] = useState<boolean | undefined>(true)
   const [showGif, setShowGif] = useState<boolean | undefined>()
-  const [showLoader, setShowLoader] = useState<boolean>()
+  const [showLoader, setShowLoader] = useState<boolean>(false)
   const [showCarouselChatButton, setShowCarouselChatButton] = useState<
     boolean | undefined
   >()


### PR DESCRIPTION
hide loader at the end of the send message event from the login and from the chat

task:
https://projects-northlatam.atlassian.net/jira/software/projects/LS/boards/223/backlog?assignee=61bb5847028e300068ae76b8&selectedIssue=LS-2975

example with a blocked user:
![image](https://user-images.githubusercontent.com/84253846/160635852-4991cab0-bd77-404b-9461-de433c7b1744.png)
![image](https://user-images.githubusercontent.com/84253846/160635868-247ae6c6-5ee2-4340-a806-89888da381c1.png)
![image](https://user-images.githubusercontent.com/84253846/160635880-3ae84ad1-7e60-479e-90b1-02386eb9471b.png)

example whit blocked word:
![image](https://user-images.githubusercontent.com/84253846/160635978-a059e929-0c2a-429b-aa75-557f85d0b8a9.png)
![image](https://user-images.githubusercontent.com/84253846/160636030-8b80d182-2d30-4873-84ab-2d4de2b1d381.png)
![image](https://user-images.githubusercontent.com/84253846/160636068-8ae554c9-c5fa-4d7c-a040-2e0964db2532.png)

